### PR TITLE
Added a progress bar to the drop analysing

### DIFF
--- a/src/main/java/mrriegel/blockdrops/Plugin.java
+++ b/src/main/java/mrriegel/blockdrops/Plugin.java
@@ -22,6 +22,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 
+import net.minecraftforge.fml.common.ProgressManager;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -66,8 +67,10 @@ public class Plugin implements IModPlugin {
 			}
 		});
 
+		ProgressManager.ProgressBar bar = ProgressManager.push("Analysing Drops", x.size());
 		for (BlockWrapper w : x) {
 			List<Drop> drops;
+			bar.step(w.block.getRegistryName().toString());
 			try {
 				drops = getList(w);
 			} catch (Exception e) {
@@ -78,6 +81,7 @@ public class Plugin implements IModPlugin {
 				continue;
 			res.add(new Wrapper(w.getStack(), drops));
 		}
+		ProgressManager.pop(bar);
 		return res;
 
 	}


### PR DESCRIPTION
I think it's a good idea, cause the first loading time is very long at my PC (two minutes) and I like it when I can see what Minecraft do.
![auswahl_020](https://cloud.githubusercontent.com/assets/12819060/16752016/39940efc-47de-11e6-92cb-2eaa7b79cea8.png)
