### PR TITLE
Changed to mod level caching of block drops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,52 @@
 /eclipse
 
 *.launch
+
+#####=== JetBrains ===#####
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+

--- a/src/main/java/mrriegel/blockdrops/Plugin.java
+++ b/src/main/java/mrriegel/blockdrops/Plugin.java
@@ -37,7 +37,7 @@ public class Plugin implements IModPlugin {
 	public void register(IModRegistry registry) {
 		registry.addRecipeCategories(new Category(registry.getJeiHelpers().getGuiHelper()));
 		registry.addRecipeHandlers(new Handler());
-		registry.addRecipes(BlockDrops.wrappers);
+		registry.addRecipes(BlockDrops.recipeWrappers);
 
 		for (Item i : Item.REGISTRY) {
 			if (i instanceof ItemPickaxe)
@@ -49,20 +49,23 @@ public class Plugin implements IModPlugin {
 	public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
 	}
 
-	public static List<Wrapper> getRecipes() {
+	public static List<Wrapper> getRecipes(Set<String> mods) {
 		List<Wrapper> res = Lists.newArrayList();
 		Set<BlockWrapper> blocks = Sets.newHashSet();
 		for (ResourceLocation r : Block.REGISTRY.getKeys()) {
-			if (BlockDrops.blacklist.contains(r.getResourceDomain()))
+			if (!mods.contains(r.getResourceDomain()))
 				continue;
+
 			Block b = Block.REGISTRY.getObject(r);
 			if (Item.getItemFromBlock(b) == null || b == Blocks.BEDROCK)
 				continue;
+
 			List<ItemStack> lis = Lists.newArrayList();
 			b.getSubBlocks(Item.getItemFromBlock(b), b.getCreativeTabToDisplayOn(), lis);
 			for (ItemStack s : lis)
 				blocks.add(new BlockWrapper(b, s.getItemDamage()));
 		}
+
 		List<BlockWrapper> x = Lists.newArrayList(blocks);
 		x.sort(new Comparator<BlockWrapper>() {
 			@Override


### PR DESCRIPTION
This reduces how often a full reload of all the block drops needs to happen to when a mod is removed which should be less often. Mod versions are stored in a new file and the old hash file is no longer used. When a new mod is added or when a mod is changed to a different version only the mods that were changed are searched for block drops.